### PR TITLE
fix: catch empty shared_account_ids

### DIFF
--- a/cloudformation.yml.tpl
+++ b/cloudformation.yml.tpl
@@ -15,6 +15,7 @@ Resources:
             %{~ endif ~}
             AmiTags:
               ${ indent(14, chomp(yamlencode(tags))) }
+            %{~ if public == true || chomp(yamlencode(shared_account_ids)) != "[]" ~}
             LaunchPermissionConfiguration:
               %{~ if public == false ~}
               UserIds:
@@ -23,6 +24,7 @@ Resources:
               UserGroups:
                 - all
               %{~ endif ~}
+            %{~ endif ~}
           %{~ if license_config_arns != null ~}
           LicenseConfigurationArns:
             ${ indent(12, chomp(yamlencode(license_config_arns)))}


### PR DESCRIPTION
I don't know why but I received the following error when recreating a pipeline:

`Error: ROLLBACK_COMPLETE: ["The following resource(s) failed to create: [distConfig, infraConfig]. . Rollback requested by user." "Resource creation cancelled" "The value supplied for parameter 'distributions[0].amiDistributionConfiguration.launchPermission.userIds' is not valid. 'distribution]AmiDistributionConfiguratioaunchPermissioserIds' must contain at least 1 items (Service: Imagebuilder, Status Code: 400, Request ID: bla-bla-bla-bla-bla, Extended Request ID: null)"]`

It worked fine before that time. The problem is that "UserIds" won't accept an empty list anymore so I added a condition around it.

I successfully tested the condition with the following combinations
public = false && shared_account_ids = "some account id" => AMI shared with "some account id"
public = false && shared_account_ids = null => AMI is private
public = true && shared_account_ids = "some account id" => AMi is public
public = true && shared_account_ids = null => AMI is public
